### PR TITLE
Update data.Rmd - formatting for numbering 

### DIFF
--- a/data.Rmd
+++ b/data.Rmd
@@ -86,6 +86,7 @@ These fields are pipe-separated in the flat file. Fields `path` and `children` c
 1. A target's file (either the one in `_targets/objects/` or a dynamic file) does not exist or changed since last time.
 
 A target's dependencies can include functions, and these functions are tracked for changes using a custom hashing procedure. When a function's hash changes, the function is considered invalidated, and so are any downstream targets with the `depend` cue turned on. The `targets` package computes the hash of a function in the following way.
+
 1. Deparse the function with `targets:::safe_deparse()`. This function computes a string representation of the function that removes comments and standardizes whitespace so that trivial changes to formatting do not cue targets to rerun.
 1. Manually remove any literal pointers from the function string using `targets:::mask_pointers()`. Such pointers arise from inline compiled C/C++ functions.
 1. Compute a hash on the preprocessed string above using `targets:::digest_chr64()`.


### PR DESCRIPTION
Added spacing so numbering renders correctly on the site.

# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-books/targets-design/blob/main/CONTRIBUTING.md).
* [] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-books/targets-design/issues) to discuss my idea with the maintainer.

# Summary
Minor formatting: 
Added spacing so numbering renders correctly on the site.

# Related GitHub issues and pull requests

* Ref: #

# Checklist

* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
